### PR TITLE
Allow hiding menu bar on Linux

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -61,7 +61,7 @@ app.on('window-all-closed', function() {
 
 // For win32, auto-hide menu bar.
 app.on('browser-window-created', function(event, window) {
-  if (process.platform === 'win32') {
+  if (process.platform === 'win32' || process.platform === 'linux') {
     if (config.hideMenuBar) {
       window.setAutoHideMenuBar(true);
       window.setMenuBarVisibility(false);


### PR DESCRIPTION
The UI feature to auto-hide the menu bar works on Linux as well as
Windows. Don't ignore it if the config value is set.