### PR TITLE
Added a skipTaskbar configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 
 test-results.xml
 test_config.json
+.idea/

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -30,7 +30,8 @@ var SettingsPage = React.createClass({
     }
     return {
       teams: config.teams,
-      hideMenuBar: config.hideMenuBar
+      hideMenuBar: config.hideMenuBar,
+      skipTaskbar: config.skipTaskbar
     };
   },
   handleTeamsChange: function(teams) {
@@ -42,6 +43,7 @@ var SettingsPage = React.createClass({
     var config = {
       teams: this.state.teams,
       hideMenuBar: this.state.hideMenuBar,
+      skipTaskbar: this.state.skipTaskbar,
       version: settings.version
     };
     settings.writeFileSync(this.props.configFile, config);
@@ -49,6 +51,7 @@ var SettingsPage = React.createClass({
       var currentWindow = remote.getCurrentWindow();
       currentWindow.setAutoHideMenuBar(config.hideMenuBar);
       currentWindow.setMenuBarVisibility(!config.hideMenuBar);
+      currentWindow.setSkipTaskbar(config.skipTaskbar);
     }
     backToIndex();
   },
@@ -58,6 +61,11 @@ var SettingsPage = React.createClass({
   handleChangeHideMenuBar: function() {
     this.setState({
       hideMenuBar: this.refs.hideMenuBar.getChecked()
+    });
+  },
+  handleChangeSkipTaskbar: function() {
+    this.setState({
+      skipTaskbar: this.refs.skipTaskbar.getChecked()
     });
   },
   render: function() {
@@ -73,6 +81,8 @@ var SettingsPage = React.createClass({
     var options = [];
     if (process.platform === 'win32' || process.platform === 'linux') {
       options.push(<Input ref="hideMenuBar" type="checkbox" label="Hide menubar (Press Alt to show menubar)" checked={ this.state.hideMenuBar } onChange={ this.handleChangeHideMenuBar } />);
+      options.push(<Input id="skipTaskbar" ref="skipTaskbar" type="checkbox" label="Hide program in Notification? (Removes it from the taskbar)" checked={ this.state.skipTaskbar } onChange={ this.handleChangeSkipTaskbar }
+                   />);
     }
     var options_row = (options.length > 0) ? (
       <Row>

--- a/src/main.js
+++ b/src/main.js
@@ -68,6 +68,9 @@ app.on('browser-window-created', function(event, window) {
       window.setAutoHideMenuBar(true);
       window.setMenuBarVisibility(false);
     }
+    if (config.skipTaskbar) {
+      window.setSkipTaskbar(true);
+    }
   }
 });
 

--- a/test/browser_test.js
+++ b/test/browser_test.js
@@ -171,6 +171,7 @@ describe('electron-mattermost', function() {
   describe('settings.html', function() {
     const config = {
       version: 1,
+      skipTaskbar: false,
       teams: [{
         name: 'example_1',
         url: mattermost_url
@@ -212,5 +213,20 @@ describe('electron-mattermost', function() {
         .end();
     });
 
+    it('should save skipTaskBar state when save is clicked', function() {
+      return client
+        .init()
+        .url('file://' + path.join(source_root_dir, 'dist/browser/settings.html'))
+        .waitForExist('#skipTaskbar')
+        .click('#skipTaskbar')
+        .pause(1000)
+        .click('#btnSave')
+        .pause(1000)
+        .then(function() {
+          var str = fs.readFileSync(config_file_path, 'utf8');
+          var result = JSON.parse(str);
+          result.skipTaskbar.should.equal(true);
+        });
+    });
   });
 });


### PR DESCRIPTION
One of my clients is using this as their primary means of communication, and I noticed that I couldn't hide it to the notification area. So I had a little time free today due to a storm knocking out my internet, and decided I should fix it.

I think I stayed within your coding standards. I added a test for the feature. I tried to add a test around whether the BrowserWindow was correctly reading the skipTaskbar config, but there seems not to be any such property. I may take another stab this weekend, and come at it from another direction.

Let me know if there's anything I can do to help out or improve!